### PR TITLE
Audio asset support with export, search indexing, and UI polish

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ Key features include:
 - Thumbnail generation for images and videos (lazy, on-demand)
 - First/last frame image variants per shot
 - Alternative video asset (alt_video) for reference, upscales, or additional video variants
+- Audio asset support (mp3, wav, ogg, flac, aac, m4a) with playback, promo, export, and search indexing
 - Shot search modal with multi-token search, content/archive filters, and keyboard navigation
 - Visual reorder modal with drag-and-drop grid, thumbnail switching, preview, and inline editing
 - Project info management (title, version, description, tags)
@@ -78,7 +79,8 @@ shotbuddy/
 ├── shots/                  # Project data directory (created per project)
 │   ├── wip/               # Work-in-progress shot folders
 │   ├── latest_images/     # Latest image versions
-│   └── latest_videos/     # Latest video versions (regular, alt)
+│   ├── latest_videos/     # Latest video versions (regular, alt)
+│   └── latest_audio/      # Latest audio versions
 ├── exports/               # Export output directory
 ├── run.py                 # Application entry point
 ├── shotbuddy.cfg          # Server configuration
@@ -143,7 +145,7 @@ Environment variables can override config file settings:
 ## Key Components
 - **ShotManager**: Core service for shot operations, file management, version tracking, thumbnail generation, and metadata handling
 - **ProjectManager**: Handles project state, recent projects (up to 6), and current project tracking
-- **FileHandler**: Manages file uploads and asset processing for all asset types including alt_video
+- **FileHandler**: Manages file uploads and asset processing for all asset types including alt_video and audio
 - **Routes**: REST API endpoints for project and shot operations
 
 ---
@@ -170,7 +172,7 @@ Environment variables can override config file settings:
 |---|---|---|---|
 | GET | `/api/shots/` | — | Get all shots with full info (ordered) |
 | POST | `/api/shots/` | — | Create new shot with gap-filling number |
-| POST | `/api/shots/upload` | Form: `file`, `shot_name`, `file_type` | Upload image/video; file_type: `image`/`first_image`/`last_image`/`video`/`alt_video` |
+| POST | `/api/shots/upload` | Form: `file`, `shot_name`, `file_type` | Upload image/video/audio; file_type: `image`/`first_image`/`last_image`/`video`/`alt_video`/`audio` |
 | POST | `/api/shots/notes` | `{shot_name, notes}` | Save shot notes (notes.txt) |
 | POST | `/api/shots/caption` | `{shot_name, asset_type, caption}` | Save caption (first_image/last_image/video/alt_video) |
 | POST | `/api/shots/prompt` | `{shot_name, asset_type, version, prompt}` | Save prompt for a specific asset version |
@@ -188,7 +190,10 @@ Environment variables can override config file settings:
 | POST | `/api/shots/export` | `{export_name, export_type, include_display_in_filename, include_metadata}` | Export latest assets + optional metadata.md with display name columns |
 | GET | `/api/shots/video/<shot_name>` | optional: `?type=video` (default) or `?type=alt_video` | Serve promoted video file |
 | GET | `/api/shots/image/<shot_name>/<asset_type>` | — | Serve promoted image (first_image/last_image) |
+| GET | `/api/shots/audio/<shot_name>` | — | Serve promoted audio file from latest_audio |
 | POST | `/api/shots/display-name` | `{shot_name, display_name}` | Set human-readable display name |
+
+> **Route alias**: `GET /api/shots/prompt_versions` is also available at `/api/shots/prompt-versions` (hyphen) — both map to the same handler.
 
 ### Request/Response Conventions
 - **Success**: `{"success": true, "data": ...}`
@@ -224,8 +229,8 @@ shot_routes.py ──→ get_shot_manager(path) ──→ ShotManager (cached pe
 ```
 
 ### Side Effects of Common Operations
-- **Creating a shot**: creates `shots/wip/SH###/` with `images/`, `videos/` subdirs; creates shot order entry; updates project timestamp
-- **Uploading an asset**: saves to `wip/SH###/images/` or `videos/` with version suffix; copies to `latest_images/` or `latest_videos/`; lazy thumbnail URL computed (generated on first request); updates version marker
+- **Creating a shot**: creates `shots/wip/SH###/` with `images/`, `videos/`, `audio/` subdirs; creates shot order entry; updates project timestamp
+- **Uploading an asset**: saves to `wip/SH###/images/`, `videos/`, or `audio/` with version suffix; copies to `latest_images/`, `latest_videos/`, or `latest_audio/`; lazy thumbnail URL computed (generated on first request for images/videos); updates version marker
 - **Promoting an asset**: copies WIP version → latest dir; updates `.version` marker; thumbnail regenerated on next request
 - **Archiving a shot**: toggles entry in `.archived_shots.json`
 
@@ -282,6 +287,10 @@ Every project directory contains these files (under `shots/`):
 ### `shots/wip/SH###/notes.txt`
 - Plain text file, read/written as-is
 
+### `shots/wip/SH###/audio/` (WIP audio files)
+- Naming: `SH###_audio_v001.mp3` (or `.wav`, `.ogg`, `.flac`, `.aac`, `.m4a`)
+- Prompt files: `SH###_audio_v001_audio_prompt.txt`
+
 ### `shots/wip/SH###/images/` (WIP image files)
 - Naming: `SH###_first_v001.png`, `SH###_last_v002.jpg`, or legacy `SH###_v001.png`
 - Prompt files: `SH###_first_v001_image_prompt.txt`, `SH###_last_v001_image_prompt.txt`
@@ -299,6 +308,11 @@ Every project directory contains these files (under `shots/`):
 ### `shots/latest_videos/`
 - Promoted finals: `SH###.mp4` (regular), `SH###_alt.mp4` (alt)
 - Version markers: `SH###.version`, `SH###_alt.version`
+- Each `.version` file contains a single integer
+
+### `shots/latest_audio/`
+- Promoted finals: `SH###.mp3` (or `.wav`, `.ogg`, `.flac`, `.aac`, `.m4a`)
+- Version markers: `SH###_audio.version`
 - Each `.version` file contains a single integer
 
 ### `.shotbuddy/thumbnails/` (per-project cache)
@@ -339,6 +353,14 @@ Every project directory contains these files (under `shots/`):
 - `image` is a legacy alias for `first_image` (backward compat)
 - Route handlers map `image` → `first_image` canonically
 
+### Audio Asset
+- `audio` = audio asset (maps to `_audio` suffix in filenames)
+- Purpose: voiceover, sound effects, music, or any audio track
+- Stored in `shots/wip/SH###/audio/` and promoted to `shots/latest_audio/`
+- Formats: `.mp3`, `.wav`, `.ogg`, `.flac`, `.aac`, `.m4a`
+- Supported across upload, version management, prompt saving, playback, captioning, export, and search indexing
+- Allowed extensions defined in `ALLOWED_AUDIO_EXTENSIONS` in `constants.py`
+
 ### Alternate Video Asset
 - `alt_video` = alternative video asset (maps to `_alt` suffix in filenames)
 - Purpose: reference video, upscaled footage, or any additional video variant
@@ -353,7 +375,7 @@ Every project directory contains these files (under `shots/`):
 - **Single SPA**: `app/templates/index.html` — one Jinja2 template, `{{ version }}` injected
 - **CSS**: `app/static/css/main.css` (primary styles, dark theme default), `app/static/css/styles.css` (light theme overrides), `app/static/css/search-modal.css` (search modal styles), `app/static/css/visual-reorder.css` (visual reorder grid styles)
 - **JavaScript**: 
-  - `app/static/js/main.js` — monolithic SPA core: shot grid, TOC, upload, export, modals, drag-and-drop, theme toggle
+  - `app/static/js/main.js` — monolithic SPA core: shot grid (with audio playback column), TOC, upload, export, modals, drag-and-drop, theme toggle
   - `app/static/js/search-modal.js` — client-side search with in-memory index, multi-token matching, filter pills, keyboard nav
   - `app/static/js/visual-reorder.js` — drag-and-drop shot sorting grid, thumbnail switching, preview/edit modes
   - `app/static/js/modal-behavior.js` — centralized click-outside and Escape-key handling for all modals
@@ -368,6 +390,7 @@ Key patterns:
 - Cache busting: appends `?t=timestamp` to media URLs
 - Modals: image/video viewers with keyboard arrow navigation; export modal with media type checkboxes and two-row button layout (utility row + centered actions); search modal with Ctrl+Shift+F shortcut; visual reorder modal with SortableJS
 - Clipboard: `copyShotOrder()` copies a zero-padded numbered list of active shots (`01. SH001 — Display Name`) to clipboard for reference in external editors
+- Audio: hidden audio DOM element for playback, constrained to `max-height: 100px` with `overflow-y: auto`; audio checkbox in export dialog; audio prompts and captions indexed in search modal
 - Drag-and-drop: custom implementation for shot reordering with grip handle; SortableJS for visual reorder grid
 - Dynamic page title: browser tab updates with project info and app version on screen transitions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,22 @@
 # Changelog
 
-## v4.1.0 (June 4, 2026) - by Taruma Sakti
+## v4.1.0 (July 4, 2026) - by Taruma Sakti
 
 ### Added
 - **Copy Shot Order button** in the export modal: copies a numbered, ordered list of all active shots (with display names if set) to the clipboard. Useful as a quick reference when working in external editors (e.g. Premiere Pro) where only SHXXX filenames are visible. Output format: `01. SH001 — Opening Scene`.
 - **Export modal two-row button layout**: utility actions (Open Exports Folder, Copy Shot Order) in the first row spaced evenly; primary actions (Export, Cancel) centered in the second row. Layout uses new `.export-utility-row` CSS class with `flex-direction: column` on `.export-actions`.
 - **Visual Reorder Image Preview**: Preview mode in the visual reorder modal now supports images (first frame and last frame) in addition to videos. Clicking a thumbnail opens the appropriate viewer — image modal for frames, video modal for videos/alt videos. Arrow-key navigation cycles through the visual reorder card DOM order for both image and video types.
+- **Audio Asset Support**: New `audio` asset type supporting `.mp3`, `.wav`, `.ogg`, `.flac`, `.aac`, and `.m4a` formats alongside existing images and videos. Includes a dedicated `latest_audio` directory with `serve_audio` playback route, versioned WIP storage in `shots/wip/SH###/audio/` (naming pattern `SH###_audio_v001.mp3`), promotion support via `ShotManager.set_current_version()` in `FileHandler.save_file()`, and an audio table in markdown export reports. The hidden audio DOM element is constrained to `max-height: 100px` with `overflow-y: auto` to prevent viewport overflow. Shot grid layout adjusted to accommodate the new audio column with playback controls.
+- **Audio Export Support**: Audio checkbox added to the export dialog in `confirmExport()`. Multi-media selection logic triggers `all` export type when multiple media categories are chosen (e.g., images + audio). Error messaging updated to reference audio alongside images and videos.
+- **Audio Search Indexing**: Audio prompts and captions are now indexed in `buildSearchIndex()` within the search modal, allowing users to find shots by their audio metadata. Matches existing search coverage for video and image prompt/caption fields.
 
 ### Fixed
 - **Thumbnail Click Broken for Display Names with Quotes**: Fixed a bug where clicking a video or image thumbnail silently failed when the shot's display name contained a single quote (e.g., "Ocean's Secret"). The unescaped quote broke the inline JavaScript `onclick` handler, producing a syntax error that prevented the preview modal from opening. Display names are now escaped before interpolation into `onclick` attributes in `createDropZone`.
 - **Unnecessary Page Rebuilds on Archive/Display Name Edit**: Removed full DOM re-renders from `archiveShot()` and `saveDisplayName()` that caused the entire shot grid to flash/repaint on every archive/unarchive or display name edit. These operations now update only the affected element directly — the archive button SVG icon flips instantly, and the display name text updates inline. Notification reminds users to press F5 to refresh layout after bulk archiving. All other operations (create, rename, upload, reorder, export) are unaffected.
+- **Project Info Data Loss Prevention**: Replaced duplicated default-project-info creation in `ProjectManager.update_project_timestamp()` with a call to `load_project_info()` when the info file is missing. If loading an existing but malformed `project_info.json` fails, a warning is logged and the update is skipped instead of overwriting with defaults, preventing potential data loss.
+
+### Changed
+- **Notification Position**: Notifications moved from `top: 20px` to `bottom: 20px` with a `translateY(20px)` slide-up animation on show/hide, preventing overlap with the sticky header navigation bar.
 
 ## v4.0.1 (June 3, 2026) - by Taruma Sakti
 

--- a/app/config/constants.py
+++ b/app/config/constants.py
@@ -8,6 +8,7 @@ PROJECTS_FILE = 'projects.json'
 MAX_RECENT_PROJECTS = 6
 ALLOWED_IMAGE_EXTENSIONS = {'.jpg', '.jpeg', '.png', '.webp'}
 ALLOWED_VIDEO_EXTENSIONS = {'.mp4', '.mov'}
+ALLOWED_AUDIO_EXTENSIONS = {'.mp3', '.wav', '.ogg', '.flac', '.aac', '.m4a'}
 
 # Central thumbnail cache location. Stored inside the application's static
 # directory so thumbnails persist across projects. The cache is cleared when

--- a/app/routes/shot_routes.py
+++ b/app/routes/shot_routes.py
@@ -493,7 +493,7 @@ def export_latest_assets():
         include_display_in_filename = data.get("include_display_in_filename", True)
         include_metadata = data.get("include_metadata", True)
 
-        if export_type not in ['images', 'videos', 'all']:
+        if export_type not in ['images', 'videos', 'audio', 'all']:
             return jsonify({"success": False, "error": "Invalid export_type"}), 400
 
         project_manager = current_app.config['PROJECT_MANAGER']
@@ -577,6 +577,33 @@ def serve_image(shot_name, asset_type):
         # Serve the image file with proper headers
         resp = send_file(str(image_file))
         resp.headers["Content-Disposition"] = f'inline; filename="{image_file.name}"'
+        resp.headers["Cache-Control"] = "public, max-age=3600"
+        return resp
+    except Exception as e:
+        return str(e), 500
+
+@shot_bp.route("/audio/<shot_name>")
+def serve_audio(shot_name):
+    """Serve the promoted audio file for a shot from latest_audio directory."""
+    try:
+        project_manager = current_app.config['PROJECT_MANAGER']
+        project = project_manager.get_current_project()
+        if not project:
+            return "No current project", 400
+
+        shot_manager = get_shot_manager(project["path"])
+        shot_info = shot_manager.get_shot_info(shot_name)
+
+        audio_path = shot_info['audio']['file']
+        if not audio_path:
+            return "No audio found for this shot", 404
+
+        audio_file = Path(audio_path)
+        if not audio_file.exists():
+            return "Audio file not found", 404
+
+        resp = send_file(str(audio_file))
+        resp.headers["Content-Disposition"] = f'inline; filename="{audio_file.name}"'
         resp.headers["Cache-Control"] = "public, max-age=3600"
         return resp
     except Exception as e:

--- a/app/services/file_handler.py
+++ b/app/services/file_handler.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from PIL import Image
 
 from app.config.constants import (
+    ALLOWED_AUDIO_EXTENSIONS,
     ALLOWED_IMAGE_EXTENSIONS,
     ALLOWED_VIDEO_EXTENSIONS,
     THUMBNAIL_SIZE,
@@ -22,10 +23,12 @@ class FileHandler:
         self.wip_dir = self.shots_dir / 'wip'
         self.latest_images_dir = self.shots_dir / 'latest_images'
         self.latest_videos_dir = self.shots_dir / 'latest_videos'
+        self.latest_audio_dir = self.shots_dir / 'latest_audio'
 
         self.wip_dir.mkdir(parents=True, exist_ok=True)
         self.latest_images_dir.mkdir(parents=True, exist_ok=True)
         self.latest_videos_dir.mkdir(parents=True, exist_ok=True)
+        self.latest_audio_dir.mkdir(parents=True, exist_ok=True)
         self.thumbnail_cache_dir = get_project_thumbnail_cache_dir(self.project_path)
 
     def clear_thumbnail_cache(self):
@@ -49,13 +52,16 @@ class FileHandler:
         # Normalize/validate file type and extension
         is_image_type = file_type in {'image', 'first_image', 'last_image'}
         is_video_type = file_type in {'video', 'alt_video'}
+        is_audio_type = file_type == 'audio'
 
         if is_image_type and file_ext not in ALLOWED_IMAGE_EXTENSIONS:
             raise ValueError(f"Invalid image format. Allowed: {', '.join(ALLOWED_IMAGE_EXTENSIONS)}")
         if is_video_type and file_ext not in ALLOWED_VIDEO_EXTENSIONS:
             raise ValueError(f"Invalid video format. Allowed: {', '.join(ALLOWED_VIDEO_EXTENSIONS)}")
+        if is_audio_type and file_ext not in ALLOWED_AUDIO_EXTENSIONS:
+            raise ValueError(f"Invalid audio format. Allowed: {', '.join(ALLOWED_AUDIO_EXTENSIONS)}")
 
-        if not (is_image_type or is_video_type):
+        if not (is_image_type or is_video_type or is_audio_type):
             raise ValueError("Invalid file_type")
 
         if not shot_dir.exists():
@@ -120,6 +126,32 @@ class FileHandler:
             # Thumbnails for videos
             thumbnail_path = self.create_video_thumbnail(str(final_path), base)
 
+        elif is_audio_type:
+            wip_dir = shot_dir / 'audio'
+            wip_dir.mkdir(exist_ok=True)
+            base = f'{shot_name}_audio'
+            version = self.get_next_version(wip_dir, base, file_ext)
+
+            wip_filename = f'{base}_v{version:03d}{file_ext}'
+            wip_path = wip_dir / wip_filename
+            file.save(str(wip_path))
+
+            final_dir = self.latest_audio_dir
+            final_path = final_dir / f'{base}{file_ext}'
+
+            for existing_file in final_dir.glob(f'{base}.*'):
+                if existing_file != wip_path:
+                    existing_file.unlink()
+
+            shutil.copy2(str(wip_path), str(final_path))
+            # Update current version marker so UI shows the promoted version correctly
+            try:
+                manager.set_current_version(shot_name, file_type, version)
+            except Exception as e:
+                logger.warning("Failed to set current version marker: %s", e)
+
+            thumbnail_path = None  # No thumbnail for audio
+
         return {
             'wip_path': str(wip_path).replace('\\', '/'),
             'final_path': str(final_path).replace('\\', '/'),
@@ -131,8 +163,13 @@ class FileHandler:
         if not wip_dir.exists():
             return 1
 
-        file_type = 'image' if 'image' in str(wip_dir) else 'video'
-        allowed_extensions = ALLOWED_IMAGE_EXTENSIONS if file_type == 'image' else ALLOWED_VIDEO_EXTENSIONS
+        wip_dir_str = str(wip_dir)
+        if 'audio' in wip_dir_str:
+            allowed_extensions = ALLOWED_AUDIO_EXTENSIONS
+        elif 'image' in wip_dir_str:
+            allowed_extensions = ALLOWED_IMAGE_EXTENSIONS
+        else:
+            allowed_extensions = ALLOWED_VIDEO_EXTENSIONS
 
         existing_files = []
         for ext in allowed_extensions:

--- a/app/services/project_manager.py
+++ b/app/services/project_manager.py
@@ -216,38 +216,23 @@ class ProjectManager:
             project_path = Path(project_path)
             project_info_path = self.get_project_info_file_path(project_path)
 
-            # Load existing project info or create defaults
-            if project_info_path.exists():
-                try:
-                    with open(project_info_path, encoding='utf-8') as f:
-                        project_info = json.load(f)
-                except Exception as e:
-                    logger.warning("Failed to load existing project info for timestamp update: %s", e)
-                    # Create default structure with created from folder ctime
-                    created_default = datetime.fromtimestamp(project_path.stat().st_ctime).isoformat()
-                    project_info = {
-                        'title': project_path.name,
-                        'description': '',
-                        'short_description': '',
-                        'notes': '',
-                        'tags': [],
-                        'created': created_default,
-                        'updated': datetime.now().isoformat(),
-                        'version': '1.0.0'
-                    }
-            else:
-                # Create default structure with created from folder ctime
-                created_default = datetime.fromtimestamp(project_path.stat().st_ctime).isoformat()
-                project_info = {
-                    'title': project_path.name,
-                    'description': '',
-                    'short_description': '',
-                    'notes': '',
-                    'tags': [],
-                    'created': created_default,
-                    'updated': datetime.now().isoformat(),
-                    'version': '1.0.0'
-                }
+            # If the file doesn't exist, create it properly (once) via load_project_info
+            if not project_info_path.exists():
+                logger.warning("project_info.json missing for %s, creating defaults", project_path)
+                self.load_project_info(project_path)
+                return
+
+            # Load existing project info
+            try:
+                with open(project_info_path, encoding='utf-8') as f:
+                    project_info = json.load(f)
+            except Exception as e:
+                # Can't read the existing file — bail out instead of destroying data
+                logger.warning(
+                    "Failed to read project_info.json for timestamp update (%s): %s",
+                    project_path, e
+                )
+                return
 
             # Update only the timestamp
             project_info['updated'] = datetime.now().isoformat()

--- a/app/services/shot_manager.py
+++ b/app/services/shot_manager.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from PIL import Image
 
 from app.config.constants import (
+    ALLOWED_AUDIO_EXTENSIONS,
     ALLOWED_IMAGE_EXTENSIONS,
     ALLOWED_VIDEO_EXTENSIONS,
     THUMBNAIL_SIZE,
@@ -89,9 +90,12 @@ class ShotManager:
         self.order_file = self.shots_dir / '.shot_order.json'
         self.archive_file = self.shots_dir / '.archived_shots.json'
 
+        self.latest_audio_dir = self.shots_dir / 'latest_audio'
+
         self.wip_dir.mkdir(parents=True, exist_ok=True)
         self.latest_images_dir.mkdir(parents=True, exist_ok=True)
         self.latest_videos_dir.mkdir(parents=True, exist_ok=True)
+        self.latest_audio_dir.mkdir(parents=True, exist_ok=True)
         self.thumbnail_cache_dir = get_project_thumbnail_cache_dir(self.project_path)
         self._version_scan_cache = {}  # (shot_name, asset_type) -> max_version
 
@@ -181,7 +185,7 @@ class ShotManager:
 
         old_dir.rename(new_dir)
 
-        for sub in ["images", "videos"]:
+        for sub in ["images", "videos", "audio"]:
             d = new_dir / sub
             if d.exists():
                 # Legacy pattern (e.g., SH001_v001.png) and new image patterns (e.g., SH001_first_v001.png)
@@ -228,6 +232,15 @@ class ShotManager:
         if alt_vid_marker.exists():
             alt_vid_marker.rename(self.latest_videos_dir / f"{new_name}_alt.version")
 
+        # Rename audio files and markers
+        for ext in ALLOWED_AUDIO_EXTENSIONS:
+            audio_src = self.latest_audio_dir / f"{old_name}_audio{ext}"
+            if audio_src.exists():
+                audio_src.rename(self.latest_audio_dir / f"{new_name}_audio{ext}")
+        audio_marker = self.latest_audio_dir / f"{old_name}_audio.version"
+        if audio_marker.exists():
+            audio_marker.rename(self.latest_audio_dir / f"{new_name}_audio.version")
+
         if self.thumbnail_cache_dir.exists():
             for thumb in self.thumbnail_cache_dir.glob(f"{old_name}_*_thumb.jpg"):
                 thumb.rename(self.thumbnail_cache_dir / thumb.name.replace(old_name, new_name, 1))
@@ -255,9 +268,11 @@ class ShotManager:
         # Create subfolders
         (shot_dir / 'images').mkdir(exist_ok=True)
         (shot_dir / 'videos').mkdir(exist_ok=True)
+        (shot_dir / 'audio').mkdir(exist_ok=True)
 
         self.latest_images_dir.mkdir(parents=True, exist_ok=True)
         self.latest_videos_dir.mkdir(parents=True, exist_ok=True)
+        self.latest_audio_dir.mkdir(parents=True, exist_ok=True)
 
         return shot_dir
 
@@ -565,6 +580,27 @@ class ShotManager:
         video_thumb = self._thumbnail_url(latest_video, shot_name, is_video=True) if latest_video else None
         alt_video_thumb = self._thumbnail_url(latest_alt_video, f"{shot_name}_alt", is_video=True) if latest_alt_video else None
 
+        # Audio
+        latest_audio, max_audio_version = self._get_latest_asset(
+            self.latest_audio_dir, shot_dir / 'audio',
+            f'{shot_name}_audio', ALLOWED_AUDIO_EXTENSIONS
+        )
+
+        if max_audio_version == 0:
+            cache_key = (shot_name, 'audio')
+            if cache_key in self._version_scan_cache:
+                detected_audio_versions = self._version_scan_cache[cache_key]
+            else:
+                detected_audio_versions = self._detect_existing_versions(shot_name, 'audio')
+                self._version_scan_cache[cache_key] = detected_audio_versions
+            max_audio_version = max(max_audio_version, detected_audio_versions)
+
+        latest_audio = self._normalize_path(latest_audio)
+        current_audio_version = self.get_current_version(shot_name, 'audio', max_audio_version)
+        audio_prompt = ''
+        if current_audio_version > 0:
+            audio_prompt = self.load_prompt(shot_name, 'audio', current_audio_version)
+
         captions = self.load_captions(shot_name)
 
         # Compose response with backward-compatible 'image' alias pointing to first_image
@@ -608,6 +644,14 @@ class ShotManager:
                 'thumbnail': alt_video_thumb,
                 'prompt': alt_video_prompt,
                 'caption': captions.get('alt_video', ''),
+            },
+            'audio': {
+                'file': latest_audio,
+                'current_version': current_audio_version,
+                'max_version': max_audio_version,
+                'thumbnail': None,  # Audio has no visual thumbnail
+                'prompt': audio_prompt,
+                'caption': captions.get('audio', ''),
             },
             'archived': (shot_name in (archived_names if archived_names is not None else self._load_archived()))
         }
@@ -661,6 +705,9 @@ class ShotManager:
         elif asset_type == 'alt_video':
             wip_dir = shot_dir / 'videos'
             patterns = [f'{shot_name}_alt_v*.*']
+        elif asset_type == 'audio':
+            wip_dir = shot_dir / 'audio'
+            patterns = [f'{shot_name}_audio_v*.*']
         else:
             return 0  # Unsupported asset type
 
@@ -696,6 +743,8 @@ class ShotManager:
             return self.latest_videos_dir / f"{shot_name}.version"
         elif asset_type == 'alt_video':
             return self.latest_videos_dir / f"{shot_name}_alt.version"
+        elif asset_type == 'audio':
+            return self.latest_audio_dir / f"{shot_name}_audio.version"
         else:
             raise ValueError('Invalid asset type')
 
@@ -736,7 +785,7 @@ class ShotManager:
     def promote_asset(self, shot_name, asset_type, version):
         """Promote a specific WIP version to be the current final for image variants/video."""
         validate_shot_name(shot_name)
-        if asset_type not in {'image', 'first_image', 'last_image', 'video', 'alt_video'}:
+        if asset_type not in {'image', 'first_image', 'last_image', 'video', 'alt_video', 'audio'}:
             raise ValueError('Invalid asset type')
 
         shot_dir = self.wip_dir / shot_name
@@ -834,6 +883,41 @@ class ShotManager:
         _ = self.get_video_thumbnail_path(final_path, base_prefix)
         return self._normalize_path(final_path)
 
+    def promote_audio_asset(self, shot_name, version):
+        """Promote a specific audio WIP version to be the current final."""
+        import shutil as _shutil
+
+        shot_dir = self.wip_dir / shot_name
+        wip_dir = shot_dir / 'audio'
+        if not wip_dir.exists():
+            raise ValueError(f"No audio WIP directory for shot {shot_name}")
+
+        base_prefix = f'{shot_name}_audio'
+
+        src = None
+        for ext in ALLOWED_AUDIO_EXTENSIONS:
+            candidate = wip_dir / f'{base_prefix}_v{int(version):03d}{ext}'
+            if candidate.exists():
+                src = candidate
+                break
+        if not src:
+            raise ValueError(f"Version v{int(version):03d} not found for {shot_name} audio")
+
+        final_dir = self.latest_audio_dir
+        final_dir.mkdir(parents=True, exist_ok=True)
+
+        for existing in final_dir.glob(f"{base_prefix}.*"):
+            try:
+                existing.unlink()
+            except Exception:
+                logger.exception("Error unlinking existing final audio")
+
+        final_path = final_dir / f"{base_prefix}{src.suffix}"
+        _shutil.copy2(str(src), str(final_path))
+
+        self.set_current_version(shot_name, 'audio', int(version))
+        return self._normalize_path(final_path)
+
     def save_shot_notes(self, shot_name, notes):
         """Save notes for a shot."""
         validate_shot_name(shot_name)
@@ -870,7 +954,7 @@ class ShotManager:
     def save_caption(self, shot_name, asset_type, caption):
         """Persist caption text for given asset type for a shot."""
         validate_shot_name(shot_name)
-        if asset_type not in {'first_image', 'last_image', 'video', 'alt_video'}:
+        if asset_type not in {'first_image', 'last_image', 'video', 'alt_video', 'audio'}:
             raise ValueError('Invalid asset type')
         shot_dir = self.wip_dir / shot_name
         if not shot_dir.exists():
@@ -902,6 +986,9 @@ class ShotManager:
         elif asset_type == 'alt_video':
             base_dir = shot_dir / 'videos'
             filename = f'{shot_name}_alt_v{version:03d}_video_prompt.txt'
+        elif asset_type == 'audio':
+            base_dir = shot_dir / 'audio'
+            filename = f'{shot_name}_audio_v{version:03d}_audio_prompt.txt'
         else:
             raise ValueError('Invalid asset type')
         return base_dir / filename
@@ -957,6 +1044,9 @@ class ShotManager:
         elif asset_type == 'alt_video':
             base_dir = shot_dir / 'videos'
             patterns = [f'{shot_name}_alt_v*_video_prompt.txt']
+        elif asset_type == 'audio':
+            base_dir = shot_dir / 'audio'
+            patterns = [f'{shot_name}_audio_v*_audio_prompt.txt']
         else:
             raise ValueError('Invalid asset type')
 
@@ -1179,6 +1269,18 @@ class ShotManager:
                         dst = videos_dir / f"{order:03d}_{shot_name}{display_suffix}_alt{ext}"
                         shutil.copy2(src, dst)
 
+            # Audio
+            if 'audio' in export_type or export_type == 'all':
+                audio_dir = export_dir / 'audio'
+                audio_dir.mkdir(exist_ok=True)
+
+                if info['audio']['file']:
+                    src = Path(info['audio']['file'])
+                    if src.exists():
+                        ext = src.suffix
+                        dst = audio_dir / f"{order:03d}_{shot_name}{display_suffix}_audio{ext}"
+                        shutil.copy2(src, dst)
+
         # Generate metadata if requested
         if include_metadata:
             # Collect data for tables and notes
@@ -1186,6 +1288,7 @@ class ShotManager:
             last_data = []
             video_data = []
             alt_video_data = []
+            audio_data = []
             notes_list = []
 
             for order, shot in enumerate(non_archived_shots, start=1):
@@ -1208,6 +1311,10 @@ class ShotManager:
                 # Alt Video
                 if ('videos' in export_type or export_type == 'all') and (info['alt_video']['caption'] or info['alt_video']['prompt']):
                     alt_video_data.append((order, shot_name, display_name, info['alt_video']['caption'], info['alt_video']['prompt']))
+
+                # Audio
+                if ('audio' in export_type or export_type == 'all') and (info['audio']['caption'] or info['audio']['prompt']):
+                    audio_data.append((order, shot_name, display_name, info['audio']['caption'], info['audio']['prompt']))
 
                 # Notes
                 if info['notes'].strip():
@@ -1278,6 +1385,17 @@ class ShotManager:
                     "|-------|-----------|--------------|----------|---------|"
                 ])
                 for order, name, display_name, caption, prompt in alt_video_data:
+                    md_lines.append(f"| {order:03d} | {name} | {display_name} | {caption.replace('|', '\\|').replace('\n', '<br>')} | {prompt.replace('|', '\\|').replace('\n', '<br>')} |")
+                md_lines.append("")
+
+            # Audio table
+            if audio_data:
+                md_lines.extend([
+                    "## Audio",
+                    "| Order | Shot Name | Display Name | Captions | Prompts |",
+                    "|-------|-----------|--------------|----------|---------|"
+                ])
+                for order, name, display_name, caption, prompt in audio_data:
                     md_lines.append(f"| {order:03d} | {name} | {display_name} | {caption.replace('|', '\\|').replace('\n', '<br>')} | {prompt.replace('|', '\\|').replace('\n', '<br>')} |")
                 md_lines.append("")
 

--- a/app/services/shot_manager.py
+++ b/app/services/shot_manager.py
@@ -841,6 +841,10 @@ class ShotManager:
             _ = self.get_thumbnail_path(final_path, shot_name)
             return self._normalize_path(final_path)
 
+        # Audio
+        if asset_type == 'audio':
+            return self.promote_audio_asset(shot_name, int(version))
+
         # Video & Alt Video
         wip_dir = shot_dir / 'videos'
         if not wip_dir.exists():

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -239,7 +239,7 @@ body {
 .grid-header {
     background: #2a2a2a;
     display: grid;
-    grid-template-columns: 32px 140px 110px 110px 110px 110px 1fr;
+    grid-template-columns: 32px 140px 110px 110px 110px 110px 110px 1fr;
     /* Actions + existing columns */
     align-items: center;
     /* Align content to center */
@@ -258,7 +258,7 @@ body {
 
 .shot-row {
     display: grid;
-    grid-template-columns: 32px 140px 110px 110px 110px 110px 1fr;
+    grid-template-columns: 32px 140px 110px 110px 110px 110px 110px 1fr;
     /* Actions + existing columns */
     border-bottom: 1px solid #404040;
     align-items: center;
@@ -1786,4 +1786,82 @@ body {
 .form-inline .form-input {
     flex: 1;
     margin: 0;
+}
+
+/* Audio Styles */
+.audio-thumbnail {
+    aspect-ratio: 4 / 3;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 48px;
+    background: #3a3a3a;
+    cursor: pointer;
+    border-radius: 4px;
+    transition: background 0.2s;
+}
+
+.audio-thumbnail:hover {
+    background: #4a4a5a;
+}
+
+/* Audio Modal Styles */
+.audio-modal-content {
+    width: 90%;
+    max-width: 600px;
+    background: #242424;
+    border-radius: 12px;
+    padding: 24px;
+    position: relative;
+}
+
+.audio-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 16px;
+}
+
+.audio-header h3 {
+    color: #e5e5e5;
+    font-size: 18px;
+    margin: 0;
+}
+
+.audio-version {
+    color: #00c851;
+    font-size: 14px;
+    font-weight: 600;
+}
+
+.audio-container {
+    width: 100%;
+    margin-bottom: 16px;
+}
+
+.audio-container audio {
+    width: 100%;
+    border-radius: 8px;
+}
+
+.audio-info {
+    background: #1a1a1a;
+    border-radius: 8px;
+    padding: 16px;
+}
+
+.audio-prompt {
+    color: #b5b5b5;
+    font-size: 14px;
+    line-height: 1.5;
+    display: none;
+}
+
+/* Light theme overrides for audio */
+.light .audio-modal-content {
+    background: #ffffff;
+}
+
+.light .audio-info {
+    background: #f5f5f5;
 }

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -1855,6 +1855,8 @@ body {
     font-size: 14px;
     line-height: 1.5;
     display: none;
+    max-height: 100px;
+    overflow-y: auto;
 }
 
 /* Light theme overrides for audio */

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -472,7 +472,7 @@ body {
 /* Notifications */
 .notification {
     position: fixed;
-    top: 20px;
+    bottom: 20px;
     right: 20px;
     background: #00c851;
     color: #1a1a1a;
@@ -480,14 +480,14 @@ body {
     border-radius: 8px;
     box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
     /* Move the notification completely off screen */
-    transform: translateX(calc(100% + 40px));
+    transform: translateX(calc(100% + 40px)) translateY(20px);
     transition: transform 0.3s ease;
     z-index: 1000;
     font-weight: 500;
 }
 
 .notification.show {
-    transform: translateX(0);
+    transform: translateX(0) translateY(0);
 }
 
 .notification.error {

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -876,6 +876,7 @@ function createShotRow(shot) {
                 ${createDropZone(shot, 'last_image')}
                 ${createDropZone(shot, 'video')}
                 ${createDropZone(shot, 'alt_video')}
+                ${createDropZone(shot, 'audio')}
                 <div class="notes-cell">
                     <textarea class="notes-input" 
                               placeholder="Add notes..." 
@@ -896,6 +897,7 @@ function displayAssetLabel(type) {
         case 'last_image': return 'Last Frame';
         case 'video': return 'Video';
         case 'alt_video': return 'Alt Video';
+        case 'audio': return 'Audio';
         default:
             return type.charAt(0).toUpperCase() + type.slice(1);
     }
@@ -910,10 +912,13 @@ function createDropZone(shot, type) {
 
     if (hasFile) {
         const isVideo = type === 'video' || type === 'alt_video';
+        const isAudio = type === 'audio';
         const thumbnailUrl = file.thumbnail ? `${file.thumbnail}?v=${Date.now()}` : null;
 
         let mediaHtml;
-        if (isVideo) {
+        if (isAudio) {
+            mediaHtml = `<div class="preview-thumbnail audio-thumbnail" onclick="playAudio('${shot.name}', '${escDn}')">&#9835;</div>`;
+        } else if (isVideo) {
             const videoStyle = thumbnailUrl ?
                 `background-image: url('${thumbnailUrl}'); background-size: cover; background-position: center;` :
                 'background: #404040;';
@@ -1049,6 +1054,7 @@ async function uploadFile(file, shotName, fileType) {
     else if (fileType === 'last_image') dropZoneIndex = 3;
     else if (fileType === 'video') dropZoneIndex = 4;
     else if (fileType === 'alt_video') dropZoneIndex = 5;
+    else if (fileType === 'audio') dropZoneIndex = 6;
     else return; // Invalid type
     const dropZone = row.children[dropZoneIndex];
     if (!dropZone || !dropZone.classList.contains('drop-zone')) {
@@ -1176,16 +1182,18 @@ function updateDropZoneForShot(shotName, assetType, shotData) {
     if (!shotRow) return;
 
     // Get the drop zone based on asset type - they appear in specific order after action-cell:
-    // [0] action-cell, [1] shot-name, [2] first_image, [3] last_image, [4] video, [5] alt_video, [6] notes
+    // [0] action-cell, [1] shot-name, [2] first_image, [3] last_image, [4] video, [5] alt_video, [6] audio, [7] notes
     let dropZone = null;
     if (assetType === 'first_image') {
-        dropZone = shotRow.children[2]; // first child after action and name
+        dropZone = shotRow.children[2];
     } else if (assetType === 'last_image') {
         dropZone = shotRow.children[3];
     } else if (assetType === 'video') {
         dropZone = shotRow.children[4];
     } else if (assetType === 'alt_video') {
         dropZone = shotRow.children[5];
+    } else if (assetType === 'audio') {
+        dropZone = shotRow.children[6];
     }
 
     if (!dropZone || !dropZone.classList.contains('drop-zone')) return;
@@ -1236,6 +1244,7 @@ function replaceDropZoneForShot(shotName, assetType, shotData) {
     else if (assetType === 'last_image') dropZoneIndex = 3;
     else if (assetType === 'video') dropZoneIndex = 4;
     else if (assetType === 'alt_video') dropZoneIndex = 5;
+    else if (assetType === 'audio') dropZoneIndex = 6;
     else return;
 
     const oldDropZone = shotRow.children[dropZoneIndex];
@@ -1352,9 +1361,11 @@ function getFileType(filename) {
     const ext = filename.toLowerCase().split('.').pop();
     const imageExts = ['jpg', 'jpeg', 'png', 'webp'];
     const videoExts = ['mp4', 'mov'];
+    const audioExts = ['mp3', 'wav', 'ogg', 'flac', 'aac', 'm4a'];
 
     if (imageExts.includes(ext)) return 'first_image'; // default image target
     if (videoExts.includes(ext)) return 'video';
+    if (audioExts.includes(ext)) return 'audio';
     return null;
 }
 
@@ -1365,6 +1376,8 @@ function openFileDialog(shotName, fileType) {
         input.accept = 'image/*';
     } else if (fileType === 'video' || fileType === 'alt_video') {
         input.accept = 'video/*';
+    } else if (fileType === 'audio') {
+        input.accept = 'audio/*';
     }
     input.style.display = 'none';
     input.addEventListener('change', () => {
@@ -1699,7 +1712,7 @@ async function savePrompt() {
         } else {
             const shot = shots.find(s => s.name === shotName);
             if (shot) {
-                if (assetType === 'first_image' || assetType === 'last_image' || assetType === 'image' || assetType === 'video' || assetType === 'alt_video') {
+                if (assetType === 'first_image' || assetType === 'last_image' || assetType === 'image' || assetType === 'video' || assetType === 'alt_video' || assetType === 'audio') {
                     const key = assetType === 'image' ? 'first_image' : assetType; // legacy map
                     if (shot[key]) {
                         shot[key].prompt = promptText;
@@ -2413,11 +2426,109 @@ function closeImageModal() {
 }
 
 
+// Audio Playback Functions
+let currentAudioShotIndex = -1;
+
+function playAudio(shotName, displayName) {
+    const shot = shots.find(s => s.name === shotName);
+    const asset = shot && shot.audio;
+    if (!asset || !asset.file) {
+        showNotification('No audio available for this shot', 'error');
+        return;
+    }
+
+    const activeShots = shots.filter(s => !s.archived && s.audio && s.audio.file);
+    currentAudioShotIndex = activeShots.findIndex(s => s.name === shotName);
+
+    const audioUrl = `/api/shots/audio/${shotName}?v=${Date.now()}`;
+    const audioPlayer = document.getElementById('audio-player');
+    const audioModalTitle = document.getElementById('audio-modal-title');
+    const audioVersion = document.getElementById('audio-version');
+    const audioPrompt = document.getElementById('audio-prompt');
+
+    audioPlayer.src = audioUrl;
+
+    if (displayName) {
+        audioModalTitle.innerHTML = `${escapeHtml(displayName)} Audio<br><span style="font-size: 14px; opacity: 0.7; font-weight: normal;">(${shotName})</span>`;
+    } else {
+        audioModalTitle.textContent = `${shotName} Audio`;
+    }
+
+    audioVersion.textContent = String(asset.current_version).padStart(3, '0');
+
+    if (asset.prompt) {
+        audioPrompt.textContent = asset.prompt;
+        audioPrompt.style.display = 'block';
+    } else {
+        audioPrompt.textContent = '';
+        audioPrompt.style.display = 'none';
+    }
+
+    document.getElementById('audio-modal').style.display = 'flex';
+    document.addEventListener('keydown', handleAudioModalKeydown);
+
+    audioPlayer.load();
+    audioPlayer.play().catch(e => {
+        console.log('Audio autoplay prevented:', e);
+    });
+}
+
+function navigateToNextAudio() {
+    const activeShots = shots.filter(s => !s.archived && s.audio && s.audio.file);
+    if (activeShots.length === 0 || currentAudioShotIndex === -1) return;
+    const nextIndex = (currentAudioShotIndex + 1) % activeShots.length;
+    const nextShot = activeShots[nextIndex];
+    if (nextShot) {
+        playAudio(nextShot.name, nextShot.display_name || '');
+    }
+}
+
+function navigateToPreviousAudio() {
+    const activeShots = shots.filter(s => !s.archived && s.audio && s.audio.file);
+    if (activeShots.length === 0 || currentAudioShotIndex === -1) return;
+    const prevIndex = (currentAudioShotIndex - 1 + activeShots.length) % activeShots.length;
+    const prevShot = activeShots[prevIndex];
+    if (prevShot) {
+        playAudio(prevShot.name, prevShot.display_name || '');
+    }
+}
+
+function handleAudioModalKeydown(event) {
+    const audioModal = document.getElementById('audio-modal');
+    if (audioModal.style.display !== 'flex') return;
+    switch (event.key) {
+        case 'ArrowLeft':
+            event.preventDefault();
+            navigateToPreviousAudio();
+            break;
+        case 'ArrowRight':
+            event.preventDefault();
+            navigateToNextAudio();
+            break;
+    }
+}
+
+function closeAudioModal() {
+    const audioModal = document.getElementById('audio-modal');
+    const audioPlayer = document.getElementById('audio-player');
+    audioModal.style.display = 'none';
+    audioPlayer.pause();
+    audioPlayer.currentTime = 0;
+    audioPlayer.src = '';
+    document.removeEventListener('keydown', handleAudioModalKeydown);
+}
+
 // Expose image functions globally
 window.showImage = showImage;
 window.closeImageModal = closeImageModal;
 window.navigateToNextImage = navigateToNextImage;
 window.navigateToPreviousImage = navigateToPreviousImage;
+
+// Expose audio functions globally
+window.playAudio = playAudio;
+window.closeAudioModal = closeAudioModal;
+window.navigateToNextAudio = navigateToNextAudio;
+window.navigateToPreviousAudio = navigateToPreviousAudio;
 
 // Expose functions globally
 window.openProjectInfoModal = openProjectInfoModal;

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -2110,19 +2110,23 @@ async function confirmExport() {
     const exportName = document.getElementById('export-name').value.trim();
     const exportImages = document.getElementById('export-images').checked;
     const exportVideos = document.getElementById('export-videos').checked;
+    const exportAudio = document.getElementById('export-audio').checked;
     const includeDisplay = document.getElementById('include-display-in-filename').checked;
     const includeMetadata = document.getElementById('include-metadata').checked;
 
     // Determine export type based on checkbox states
     let exportType;
-    if (exportImages && exportVideos) {
+    const selectedCount = (exportImages ? 1 : 0) + (exportVideos ? 1 : 0) + (exportAudio ? 1 : 0);
+    if (selectedCount > 1) {
         exportType = 'all';
     } else if (exportImages) {
         exportType = 'images';
     } else if (exportVideos) {
         exportType = 'videos';
+    } else if (exportAudio) {
+        exportType = 'audio';
     } else {
-        showNotification('Please select at least one export option (Images or Videos)', 'error');
+        showNotification('Please select at least one export option (Images, Videos, or Audio)', 'error');
         return;
     }
 

--- a/app/static/js/modal-behavior.js
+++ b/app/static/js/modal-behavior.js
@@ -14,7 +14,8 @@ var _modalCloseMap = {
     'project-info-modal': closeProjectInfoModal,
     'export-modal': closeExportModal,
     'video-modal': closeVideoModal,
-    'image-modal': closeImageModal
+    'image-modal': closeImageModal,
+    'audio-modal': closeAudioModal
 };
 
 // Click outside modal content → close

--- a/app/static/js/search-modal.js
+++ b/app/static/js/search-modal.js
@@ -58,6 +58,14 @@ function buildSearchIndex() {
             if (caption) items.push({ field: 'Alt Video Caption', text: caption, badgeType: 'caption', assetLabel: 'Alt Video' });
         }
 
+        // Audio: prompt + caption
+        if (shot.audio) {
+            var prompt = (shot.audio.prompt || '').trim();
+            var caption = (shot.audio.caption || '').trim();
+            if (prompt) items.push({ field: 'Audio Prompt', text: prompt, badgeType: 'prompt', assetLabel: 'Audio' });
+            if (caption) items.push({ field: 'Audio Caption', text: caption, badgeType: 'caption', assetLabel: 'Audio' });
+        }
+
         // Notes
         var notes = (shot.notes || '').trim();
         if (notes) items.push({ field: 'Notes', text: notes, badgeType: 'notes-badge', assetLabel: '' });

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -142,6 +142,7 @@
                     <div class="grid-header-cell">Last Frame</div>
                     <div class="grid-header-cell">Video</div>
                     <div class="grid-header-cell">Alt Video</div>
+                    <div class="grid-header-cell">Audio</div>
                     <div class="grid-header-cell">Notes</div>
                 </div>
                 <div id="shot-list"></div>
@@ -328,6 +329,11 @@
                             <span class="checkbox-custom"></span>
                             <span class="checkbox-text">Videos</span>
                         </label>
+                        <label class="checkbox-label checkbox-inline">
+                            <input id="export-audio" type="checkbox" checked class="export-checkbox" />
+                            <span class="checkbox-custom"></span>
+                            <span class="checkbox-text">Audio</span>
+                        </label>
                     </div>
                 </div>
 
@@ -387,6 +393,35 @@
             </svg>
         </button>
         <button class="nav-arrow nav-arrow-right" onclick="navigateToNextShot()" aria-label="Next shot">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="9 18 15 12 9 6"></polyline>
+            </svg>
+        </button>
+    </div>
+
+    <!-- Audio Playback Modal -->
+    <div id="audio-modal" class="modal">
+        <div class="modal-content audio-modal-content">
+            <button class="close-modal" onclick="closeAudioModal()">&times;</button>
+            <div class="audio-header">
+                <h3 id="audio-modal-title"></h3>
+                <div class="audio-version">v<span id="audio-version"></span></div>
+            </div>
+            <div class="audio-container">
+                <audio id="audio-player" controls>
+                    Your browser does not support the audio tag.
+                </audio>
+            </div>
+            <div class="audio-info">
+                <div id="audio-prompt" class="audio-prompt"></div>
+            </div>
+        </div>
+        <button class="nav-arrow nav-arrow-left" onclick="navigateToPreviousAudio()" aria-label="Previous shot">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="15 18 9 12 15 6"></polyline>
+            </svg>
+        </button>
+        <button class="nav-arrow nav-arrow-right" onclick="navigateToNextAudio()" aria-label="Next shot">
             <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <polyline points="9 18 15 12 9 6"></polyline>
             </svg>


### PR DESCRIPTION
### Summary
Adds comprehensive audio asset support to ShotBuddy, enabling upload, playback, promotion, export, and search indexing of audio files (`.mp3`, `.wav`, `.ogg`, `.flac`, `.aac`, `.m4a`). Also includes bug fixes for project info data loss and UI improvements to notification positioning.

### What's Changed

#### 🎵 Audio Asset Support (main feature)
- New `audio` asset type with dedicated `latest_audio/` directory and `shots/wip/SH###/audio/` WIP storage (`SH###_audio_v001.mp3` naming pattern)
- `GET /api/shots/audio/<shot_name>` serve route for playback
- Promotion support via `ShotManager.set_current_version()` in `FileHandler.save_file()`
- Audio table in markdown export reports
- Shot grid layout updated with audio column and playback controls
- Audio DOM element constrained to `max-height: 100px` with `overflow-y: auto`

#### 🔍 Search & Export
- Audio prompts and captions indexed in `buildSearchIndex()` for search modal coverage
- Audio checkbox in export dialog; multi-media selection triggers combined export type

#### 🐛 Bug Fixes
- **Data loss prevention**: `update_project_timestamp()` no longer overwrites malformed `project_info.json` with defaults; defers to `load_project_info()` when file is missing instead of duplicating default creation

#### 🎨 UI Improvements
- Notifications repositioned to `bottom: 20px` with slide-up animation (no longer overlaps sticky header)
- Scrollable hidden audio DOM element prevents viewport overflow

#### 📝 Documentation
- `AGENTS.md` updated with full audio asset schema, API reference, and data flow docs
- `CHANGELOG.md` updated with v4.1.0 entries